### PR TITLE
Fixes for VM deletion

### DIFF
--- a/lib/proxmox.js
+++ b/lib/proxmox.js
@@ -38,7 +38,7 @@ module.exports = function(name, pwd, hostname) {
 	command += ('-d ' + data);
 	return this;
     };
-    this.delete = function(url, data, header, cookie) {
+    this.del = function(url, data, header, cookie) {
 	command = 'curl -X DELETE -k ';
         command += ('-b ' + 'PVEAuthCookie='+cookie + ' ');
 	command += ('-H ' +'"'+'CSRFPreventionToken:' + header + '"'+' ');	   
@@ -321,7 +321,7 @@ module.exports = function(name, pwd, hostname) {
 		},
 		deleteOpenvzContainer: function(node, vmid, callback) {
 		  data = {};
-		  url = '/nodes/'+node+'/openvz'+vmid;
+		  url = '/nodes/'+node+'/openvz/'+vmid;
 		  del(url, data, callback);
 		},
 		setOpenvzContainerOptions: function(node, vmid, data, calback) {


### PR DESCRIPTION
- curlCom.delete -> curlCom.del (it was called throughout the code as curlCom.del)
- Missing slash causing VM deletion to fail